### PR TITLE
Update Discovered.js

### DIFF
--- a/lib/modules/Discovered.js
+++ b/lib/modules/Discovered.js
@@ -4,15 +4,17 @@
 const Discovered = function (req) {
 	this.req = req
 	
-	this.service = new Service()
-	this.host = new Host()
+	this.service = new Service(req)
+	this.host = new Host(req)
 }
 
 
 /**
 * @constructs Service
 */
-const Service = function() {}
+const Service = function(req) {
+	this.req = req
+}
 
 
 /**
@@ -31,7 +33,9 @@ Service.prototype.get = function (params) {
 /**
 * @constructs Host
 */
-const Host = function() {}
+const Host = function(req) {
+	this.req = req
+}
 
 
 /**


### PR DESCRIPTION
FIX: The 'req' parameter was not passed to the 'Host' and 'Service' sub-modules of the 'Discovered' module.