### PR TITLE
Typo

### DIFF
--- a/lib/modules/HostGroup.js
+++ b/lib/modules/HostGroup.js
@@ -3,7 +3,7 @@
 */
 const HostGroup = function (req) {
 	this.req = req
-	this.mass = new Mass(res)
+	this.mass = new Mass(req)
 }
 
 


### PR DESCRIPTION
HostGroup.js had a typo where a reference to the variable 'req' was misspelled as 'res', causing an error.